### PR TITLE
tracking: clearEnv on CommandBuilder

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -691,6 +691,46 @@ Deno.test("exporting env should modify real environment when something changed v
   }
 });
 
+Deno.test("env should be clean slate when clearEnv is set", async () => {
+  {
+    const text = await $`printenv`.clearEnv().text();
+    assertEquals(text, "");
+  }
+  {
+    const text = await $`deno eval 'console.log(JSON.stringify(Deno.env.toObject()))'`.clearEnv().text();
+    assertEquals(text, "{}");
+  }
+  Deno.env.set("DAX_TVAR", "123");
+  try {
+    const text = await $`deno eval 'console.log("DAX_TVAR: " + Deno.env.get("DAX_TVAR"))'`.clearEnv().text();
+    assertEquals(text, "DAX_TVAR: undefined");
+  } finally {
+    Deno.env.delete("DAX_TVAR");
+  }
+});
+
+Deno.test("clearEnv + exportEnv should not clear out real environment", async () => {
+  Deno.env.set("DAX_TVAR", "123");
+  try {
+    const text1 = await $`deno eval 'console.log(JSON.stringify(Deno.env.toObject()))'`
+      .clearEnv()
+      .exportEnv()
+      .text();
+    assertEquals(text1, "{}");
+    const text =
+      await $`deno eval 'console.log("VAR: " + Deno.env.get("DAX_TVAR") + " VAR2: " + Deno.env.get("DAX_TVAR2"))'`
+        .env("DAX_TVAR2", "shake it shake")
+        .clearEnv()
+        .exportEnv()
+        .text();
+    assertEquals(text, "VAR: undefined VAR2: shake it shake");
+    assertEquals(Deno.env.get("DAX_TVAR2"), "shake it shake");
+  } finally {
+    Deno.env.delete("DAX_TVAR");
+    Deno.env.delete("DAX_TVAR2");
+  }
+});
+
 Deno.test("setting an empty env var", async () => {
   const text = await $`VAR= deno eval 'console.log("VAR: " + Deno.env.get("VAR"))'`.text();
   assertEquals(text, "VAR: ");

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -696,10 +696,6 @@ Deno.test("env should be clean slate when clearEnv is set", async () => {
     const text = await $`printenv`.clearEnv().text();
     assertEquals(text, "");
   }
-  {
-    const text = await $`deno eval 'console.log(JSON.stringify(Deno.env.toObject()))'`.clearEnv().text();
-    assertEquals(text, "{}");
-  }
   Deno.env.set("DAX_TVAR", "123");
   try {
     const text = await $`deno eval 'console.log("DAX_TVAR: " + Deno.env.get("DAX_TVAR"))'`.clearEnv().text();
@@ -712,11 +708,6 @@ Deno.test("env should be clean slate when clearEnv is set", async () => {
 Deno.test("clearEnv + exportEnv should not clear out real environment", async () => {
   Deno.env.set("DAX_TVAR", "123");
   try {
-    const text1 = await $`deno eval 'console.log(JSON.stringify(Deno.env.toObject()))'`
-      .clearEnv()
-      .exportEnv()
-      .text();
-    assertEquals(text1, "{}");
     const text =
       await $`deno eval 'console.log("VAR: " + Deno.env.get("DAX_TVAR") + " VAR2: " + Deno.env.get("DAX_TVAR2"))'`
         .env("DAX_TVAR2", "shake it shake")

--- a/src/command.ts
+++ b/src/command.ts
@@ -79,6 +79,7 @@ interface CommandBuilderState {
   env: Record<string, string | undefined>;
   commands: Record<string, CommandHandler>;
   cwd: string | undefined;
+  clearEnv: boolean;
   exportEnv: boolean;
   printCommand: boolean;
   printCommandLogger: LoggerTreeBox;
@@ -147,6 +148,7 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
     env: {},
     cwd: undefined,
     commands: { ...builtInCommands },
+    clearEnv: false,
     exportEnv: false,
     printCommand: false,
     printCommandLogger: new LoggerTreeBox(
@@ -176,6 +178,7 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
       env: { ...state.env },
       cwd: state.cwd,
       commands: { ...state.commands },
+      clearEnv: state.clearEnv,
       exportEnv: state.exportEnv,
       printCommand: state.printCommand,
       printCommandLogger: state.printCommandLogger.createChild(),
@@ -451,6 +454,18 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
   exportEnv(value = true): CommandBuilder {
     return this.#newWithState((state) => {
       state.exportEnv = value;
+    });
+  }
+
+  /**
+   * Clear environmental variables from parent process.
+   *
+   * Doesn't guarantee that only `env` variables are present, as the OS may
+   * set environmental variables for processes.
+   */
+  clearEnv(value = true): CommandBuilder {
+    return this.#newWithState((state) => {
+      state.clearEnv = value;
     });
   }
 
@@ -742,10 +757,11 @@ export function parseAndSpawnCommand(state: CommandBuilderState) {
         stdin: stdin instanceof ReadableStream ? readerFromStreamReader(stdin.getReader()) : stdin,
         stdout,
         stderr,
-        env: buildEnv(state.env),
+        env: buildEnv(state.env, state.clearEnv),
         commands: state.commands,
         cwd: state.cwd ?? Deno.cwd(),
         exportEnv: state.exportEnv,
+        clearedEnv: state.clearEnv,
         signal,
         fds,
       });
@@ -1083,8 +1099,8 @@ export class CommandResult {
   }
 }
 
-function buildEnv(env: Record<string, string | undefined>) {
-  const result = Deno.env.toObject();
+function buildEnv(env: Record<string, string | undefined>, clearEnv: boolean) {
+  const result = clearEnv ? {} : Deno.env.toObject();
   for (const [key, value] of Object.entries(env)) {
     if (value == null) {
       delete result[key];
@@ -1092,6 +1108,7 @@ function buildEnv(env: Record<string, string | undefined>) {
       result[key] = value;
     }
   }
+  console.log({ result });
   return result;
 }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -1108,7 +1108,6 @@ function buildEnv(env: Record<string, string | undefined>, clearEnv: boolean) {
       result[key] = value;
     }
   }
-  console.log({ result });
   return result;
 }
 


### PR DESCRIPTION
Get the ball rolling while we wait for https://github.com/dsherret/dax/pull/264 to land on a JSR release. Don't merge this PR but instead close it when upstream gets merged. Only here as a tracking reference for #3.